### PR TITLE
Fix PHP 8.1 deprecation in transposh_options.php

### DIFF
--- a/wp/transposh_options.php
+++ b/wp/transposh_options.php
@@ -190,6 +190,9 @@ class transposh_plugin_options {
     // private $vars array() = (1,2,3);
 
     function register_option($name, $type, $default_value = '') {
+		if ( ! is_array( $this->options ) ) {
+			$this->options = array();
+		}        
         if (!isset($this->options[$name]))
             $this->options[$name] = $default_value;
         // can't log...     tp_logger($name . ' ' . $this->options[$name]);


### PR DESCRIPTION
This PR fixes a "Deprecated: Automatic conversion of false to array" warning in wp/transposh_options.php on line 194.
The issue occurs when $this->options is initialized as false (e.g., when no options are yet stored in the DB) and a value is assigned to a key.
The fix ensures $this->options is cast to an array before the assignment.